### PR TITLE
fix: use NODE_AUTH_TOKEN in .yarnrc.yml for setup-node@v7 compatibility

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ jobs:
     name: "build"
     runs-on: "ubuntu-latest"
     env:
-      NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
     permissions:
       contents: "read"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     name: "build"
     runs-on: "ubuntu-latest"
     env:
-      NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
     permissions:
       contents: "read"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,7 +5,7 @@ npmMinimalAgeGate: 2880
 npmScopes:
   navikt:
     npmAlwaysAuth: true
-    npmAuthToken: "${NPM_AUTH_TOKEN:-}"
+    npmAuthToken: "${NODE_AUTH_TOKEN:-}"
     npmRegistryServer: "https://npm.pkg.github.com"
 
 # Sikkerhetstiltak


### PR DESCRIPTION
## Problem
`actions/setup-node@v7` removed the dummy `NODE_AUTH_TOKEN` export and no longer recognizes `NPM_AUTH_TOKEN`. Yarn berry reads auth directly from `.yarnrc.yml`, so the token reference must match the env var that `setup-node` sets.

## Change
Rename `NPM_AUTH_TOKEN` → `NODE_AUTH_TOKEN` in `.yarnrc.yml`.

Same fix applied in navikt/mine-aap.