### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aap
   labels:
     team: aap
+    systemkatalog.nav.no/system: TE-496
 spec:
   observability:
     autoInstrumentation:

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: aap
   labels:
     team: aap
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
 spec:
   observability:
     autoInstrumentation:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aap
   labels:
     team: aap
+    systemkatalog.nav.no/system: TE-496
 spec:
   observability:
     autoInstrumentation:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: aap
   labels:
     team: aap
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
 spec:
   observability:
     autoInstrumentation:


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.